### PR TITLE
fix: condition to execute "npm-published" Github workflow

### DIFF
--- a/.github/workflows/npm-published.yaml
+++ b/.github/workflows/npm-published.yaml
@@ -9,23 +9,20 @@
 name: Upload NPM Package
 
 on:
-  workflow_run:
-    workflows: [ "Tagging" ]
-    types:
-      - completed
+  push:
+    tags:
+      - "*"
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm ci
       - name: Publish package


### PR DESCRIPTION
There seems to be a concurrency issue when it comes to these 2 Github workflows: `tagging` and `npm-published`. 

For example, it happened an hour ago and the same thing happened several times in the past. For instance here: https://github.com/Qovery/qovery-client-typescript-axios/actions/runs/14708569296

A first commit is added to main when a PR is merged. At that moment, the `tagging` workflow updates the version number and creates a new tag and. The `npm-published` workflow is supposed to be executed after the tag has been created. 
However, it appears that the `npm-published` workflow is sometimes executed before the version is bumped.
This PR ensures that the `npm-published` workflow runs after the tag is created.