### PR TITLE
Update npm-published.yaml to use OIDC with NPM

### DIFF
--- a/.github/workflows/npm-published.yaml
+++ b/.github/workflows/npm-published.yaml
@@ -14,6 +14,10 @@ on:
     types:
       - completed
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   deploy:
 
@@ -30,5 +34,3 @@ jobs:
         run: npm ci
       - name: Publish package
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Following doc here: https://docs.npmjs.com/trusted-publishers
Maybe we should update official github actions `actions/checkout@v2` to `v6` and `actions/setup-node@v2` to `v6`, but as this would update to underlying `node` runtime, I'm unsure.